### PR TITLE
change access modifier for s_amsiInitFailed

### DIFF
--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -1694,7 +1694,7 @@ namespace System.Management.Automation
         [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private static IntPtr s_amsiSession = IntPtr.Zero;
 
-        private static bool s_amsiInitFailed = false;
+        internal static bool s_amsiInitFailed = false;
         private static object s_amsiLockObject = new Object();
 
         /// <summary>


### PR DESCRIPTION
Attacker may bypass AMSI by adding "[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed','NonPublic,Static').SetValue($null,$true)" to script.  This attack was described in this article: http://www.labofapenetrationtester.com/2016/09/amsi.html